### PR TITLE
Implement OT/NT Filters for Search

### DIFF
--- a/lib/src/screens/search_screen.dart
+++ b/lib/src/screens/search_screen.dart
@@ -9,6 +9,7 @@ import '../utils/text_utils.dart';
 
 class SearchScreen extends ConsumerStatefulWidget {
   final List<Verse> verses;
+
   const SearchScreen(this.verses, {super.key});
 
   @override
@@ -34,7 +35,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
           .replaceAll(" ", "")
           .toLowerCase()
           .contains(
-              _searchController.text.trim().replaceAll(" ", "").toLowerCase());
+          _searchController.text.trim().replaceAll(" ", "").toLowerCase());
       if (matchVerse) {
         bool contains = _results.any((element) => element == verse);
         if (!contains) {
@@ -57,12 +58,12 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   @override
   Widget build(BuildContext context) {
     final resultBooks =
-        _results.map((toElement) => toElement.book).toSet().toList();
+    _results.map((toElement) => toElement.book).toSet().toList();
 
+    final books = BibleDatabase.books;
     resultBooks.sortByCompare(
-      (keyOf) => keyOf,
-      (a, b) {
-        final books = BibleDatabase.books;
+          (keyOf) => keyOf,
+          (a, b) {
         int indexA = books.indexOf(a);
         int indexB = books.indexOf(b);
 
@@ -70,9 +71,28 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       },
     );
 
-    final filteredResult = _selectedBook == "All"
-        ? _results
-        : _results.where((test) => test.book == _selectedBook).toList();
+    // Insert 'OT' & 'NT' to resultbooks
+    resultBooks.insert(0, "NT");
+    resultBooks.insert(0, "OT");
+
+    List<Verse> filteredResult = [];
+
+    if (_selectedBook == "All") {
+      filteredResult = _results;
+    } else if (_selectedBook == "OT") {
+      filteredResult =
+          _results.where((verse) => books.indexOf(verse.book) < 39).toList();
+      resultBooks.removeWhere((book) =>
+      books.indexOf(book) > 38 && book != "OT" && book != "NT");
+    } else if (_selectedBook == "NT") {
+      filteredResult =
+          _results.where((verse) => books.indexOf(verse.book) > 38).toList();
+      resultBooks.removeWhere((book) =>
+      books.indexOf(book) < 39 && book != "OT" && book != "NT");
+    } else {
+      filteredResult =
+          _results.where((verse) => verse.book == _selectedBook).toList();
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -86,7 +106,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
           ),
           onChanged: (o) => setState(() {}),
           onSubmitted: (s) async =>
-              await search().then((_) => _scrollController.jumpTo(0.0)),
+          await search().then((_) => _scrollController.jumpTo(0.0)),
           textInputAction: TextInputAction.search,
         ),
         actions: [
@@ -119,88 +139,97 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
                 itemBuilder: (context, index) {
                   final book = resultBooks[index];
 
+                  // Calculate the result count for each book and for verses in books in OT and NT
                   final resultCount = _results
-                      .where((test) => test.book == book)
+                      .where((verse) =>
+                  verse.book == book || book == "OT" && books.indexOf(
+                      verse.book) < 39
+                      && books.indexOf(verse.book) >= 0 ||
+                      book == "NT" && books.indexOf(verse.book) > 38)
                       .toList()
                       .length;
 
+
                   return index == 0
                       ? Row(
-                          children: [
-                            Center(
-                              child: GestureDetector(
-                                onTap: () {
-                                  _onTap("All");
-                                },
-                                child: Card(
-                                  color: "All" == _selectedBook
-                                      ? Theme.of(context)
-                                          .colorScheme
-                                          .primaryContainer
-                                      : null,
-                                  margin: EdgeInsets.only(
-                                      left: 14.0,
-                                      right: index == (resultBooks.length - 1)
-                                          ? 14.0
-                                          : 0.0),
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                        horizontal: 8.0, vertical: 4.0),
-                                    child: Text("All ${_results.length}"),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Center(
-                              child: GestureDetector(
-                                onTap: () {
-                                  _onTap(book);
-                                },
-                                child: Card(
-                                  color: book == _selectedBook
-                                      ? Theme.of(context)
-                                          .colorScheme
-                                          .primaryContainer
-                                      : null,
-                                  margin: EdgeInsets.only(
-                                      left: 14.0,
-                                      right: index == (resultBooks.length - 1)
-                                          ? 14.0
-                                          : 0.0),
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                        horizontal: 8.0, vertical: 4.0),
-                                    child: Text("$book $resultCount"),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        )
-                      : Center(
-                          child: GestureDetector(
-                            onTap: () {
-                              _onTap(book);
-                            },
-                            child: Card(
-                              color: book == _selectedBook
-                                  ? Theme.of(context)
-                                      .colorScheme
-                                      .primaryContainer
-                                  : null,
-                              margin: EdgeInsets.only(
-                                  left: 14.0,
-                                  right: index == (resultBooks.length - 1)
-                                      ? 14.0
-                                      : 0.0),
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 8.0, vertical: 4.0),
-                                child: Text("$book $resultCount"),
-                              ),
+                    children: [
+                      Center(
+                        child: GestureDetector(
+                          onTap: () {
+                            _onTap("All");
+                          },
+                          child: Card(
+                            color: "All" == _selectedBook
+                                ? Theme
+                                .of(context)
+                                .colorScheme
+                                .primaryContainer
+                                : null,
+                            margin: EdgeInsets.only(
+                                left: 14.0,
+                                right: index == (resultBooks.length - 1)
+                                    ? 14.0
+                                    : 0.0),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8.0, vertical: 4.0),
+                              child: Text("All ${_results.length}"),
                             ),
                           ),
-                        );
+                        ),
+                      ),
+                      Center(
+                        child: GestureDetector(
+                          onTap: () {
+                            _onTap(book);
+                          },
+                          child: Card(
+                            color: book == _selectedBook
+                                ? Theme
+                                .of(context)
+                                .colorScheme
+                                .primaryContainer
+                                : null,
+                            margin: EdgeInsets.only(
+                                left: 14.0,
+                                right: index == (resultBooks.length - 1)
+                                    ? 14.0
+                                    : 0.0),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8.0, vertical: 4.0),
+                              child: Text("$book $resultCount"),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                      : Center(
+                    child: GestureDetector(
+                      onTap: () {
+                        _onTap(book);
+                      },
+                      child: Card(
+                        color: book == _selectedBook
+                            ? Theme
+                            .of(context)
+                            .colorScheme
+                            .primaryContainer
+                            : null,
+                        margin: EdgeInsets.only(
+                            left: 14.0,
+                            right: index == (resultBooks.length - 1)
+                                ? 14.0
+                                : 0.0),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 8.0, vertical: 4.0),
+                          child: Text("$book $resultCount"),
+                        ),
+                      ),
+                    ),
+                  );
                 },
               ),
             ),
@@ -215,14 +244,16 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
                 return DecoratedBox(
                   decoration: BoxDecoration(
                     border: Border(
-                      bottom: BorderSide(color: Theme.of(context).hoverColor),
+                      bottom: BorderSide(color: Theme
+                          .of(context)
+                          .hoverColor),
                     ),
                   ),
                   child: ListTile(
                     onTap: () {
                       int idx = widget.verses.indexWhere(
-                        (element) =>
-                            element.chapter == verse.chapter &&
+                            (element) =>
+                        element.chapter == verse.chapter &&
                             element.book == verse.book &&
                             element.verse == verse.verse,
                       );
@@ -234,7 +265,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
                         text: _searchController.text.trim(),
                         context: context),
                     subtitle:
-                        Text("${verse.book} ${verse.chapter}:${verse.verse}"),
+                    Text("${verse.book} ${verse.chapter}:${verse.verse}"),
                   ),
                 );
               },


### PR DESCRIPTION
### -> This pull request introduces Old Testament (OT) and New Testament (NT) filters to the search functionality.

## Problem
-   Previously, searching for verses did not allow users to narrow down results by testament.
-   This could make it time-consuming to find specific verses, especially if the verse was in the New Testament.

## Solution
-   Added OT and NT filters to the search results.
-   When either filter is selected:
    -   The search results will be limited to verses and books from the respective testament.
    -   The OT filter will show verses and books from the Old Testament.
    -   The NT filter will show verses and books from the New Testament.
-   This allows users to quickly narrow down their search and find the verses they are looking for.
-   This significantly improves search speed, especially when searching for verses in the New Testament.

## How
-   Modified the search logic to include filtering by testament.
-   Updated the search UI to include OT and NT filter options.


- Some extra 'irreversible' code formatting from android-studio
