### PR TITLE
Fixed bug when changing bible versions.

### DIFF
--- a/lib/src/providers/version_provider.dart
+++ b/lib/src/providers/version_provider.dart
@@ -6,3 +6,7 @@ import '../models/bible_version_model.dart';
 final versionProvider = StateProvider<BibleVersion>((ref) {
   return BibleDatabase.bibleVersions.first;
 });
+
+final versionChangedProvider = StateProvider<bool>((ref) {
+    return false;
+});

--- a/lib/src/screens/home_screen.dart
+++ b/lib/src/screens/home_screen.dart
@@ -70,7 +70,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
             if (firstVerseInViewPort.book != previousActiveVerse.book ||
                 firstVerseInViewPort.chapter != previousActiveVerse.chapter) {
-              ref.read(lastIndexProvider.notifier).state = firstIndex;
+              if (!ref.read(versionChangedProvider)) {
+                ref.read(lastIndexProvider.notifier).state = firstIndex;
+                } else {
+                  ref.read(versionChangedProvider.notifier).state = false;
+                }
               _activeVerse = firstVerseInViewPort;
             }
           },

--- a/lib/src/services/show_versions.dart
+++ b/lib/src/services/show_versions.dart
@@ -76,6 +76,8 @@ class __VersionsViewState extends ConsumerState<_VersionsView> {
 
     ref.read(versionProvider.notifier).state = version;
 
+    ref.read(versionChangedProvider.notifier).state = true;
+
     final index = ref.read(lastIndexProvider);
 
     ScrollControllerProvider.jumpTo(ref: ref, index: index);


### PR DESCRIPTION
**Bug**

- When changing versions the verse would reset to Gen 1:1
- Caused by lastindexprovider being rewritten when homescreen refreshes

**Approach / Solution**

- Add a provider for when the version is changed with state as boolean.
- Set the provider to true when the version is changed.
- Let lastindexprovider be rewritten only if the version was not recently changed to allow the homescreen to return to previous scrollstate.
